### PR TITLE
fix: resolve ESLint errors and React duplicate-key warning

### DIFF
--- a/components/ConfigWizard.tsx
+++ b/components/ConfigWizard.tsx
@@ -156,7 +156,7 @@ function getSettingMeta(key: string): SettingMeta | null {
             if (s.key === key) {
                 const meta = { ...s } as SettingMeta;
                 if (key === 'DrivingModel' && !meta.options) {
-                    const allModels = (modelsData.categories as any[]).flatMap(c => c.models.map((m: any) => m.name));
+                    const allModels = (modelsData.categories as Array<{ models: Array<{ name: string }> }>).flatMap(c => c.models.map((m) => m.name));
                     meta.options = ['Default', ...allModels];
                 }
                 return meta;
@@ -358,7 +358,7 @@ function WelcomeStep({ onNext }: { onNext: () => void }) {
                 </div>
                 <p className="text-slate-400 max-w-lg mx-auto leading-relaxed">
                     Build a complete, device-ready sunnypilot configuration file in minutes.
-                    We'll guide you through every setting with community-tested recommendations for your specific vehicle.
+                    We&apos;ll guide you through every setting with community-tested recommendations for your specific vehicle.
                 </p>
             </div>
 

--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -38,8 +38,9 @@ export default function LanguageSwitcher() {
     const handleSelect = (newLocale: Locale) => {
         if (newLocale !== locale) {
             // Track language switch in Google Analytics
-            if (typeof window !== 'undefined' && typeof (window as any).gtag === 'function') {
-                (window as any).gtag('event', 'language_switch', {
+            const gtag = (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag;
+            if (typeof window !== 'undefined' && typeof gtag === 'function') {
+                gtag('event', 'language_switch', {
                     previous_language: locale,
                     new_language: newLocale,
                     language_name: localeMeta[newLocale].name,

--- a/components/ModelLibrary (1).tsx
+++ b/components/ModelLibrary (1).tsx
@@ -572,7 +572,7 @@ export default function ModelLibrary() {
                             </div>
                             <select
                                 value={sortBy}
-                                onChange={(e) => setSortBy(e.target.value as any)}
+                                onChange={(e) => setSortBy(e.target.value)}
                                 className="
                                     appearance-none w-full bg-slate-800/50 border border-slate-700/50 rounded-xl
                                     pl-14 pr-10 py-2.5 text-sm font-medium text-white

--- a/components/ModelLibrary.tsx
+++ b/components/ModelLibrary.tsx
@@ -257,8 +257,8 @@ function ModelCard({ model }: { model: Model }) {
                 <div className="mt-3 pt-3 border-t border-slate-700/50">
                     <p className="text-xs text-slate-500 mb-1">🚗 Tested on:</p>
                     <div className="flex flex-wrap gap-1">
-                        {model.testedOn.map((car) => (
-                            <span key={car} className="px-2 py-0.5 text-[10px] rounded bg-slate-800 text-slate-400">
+                        {model.testedOn.map((car, i) => (
+                            <span key={`${car}-${i}`} className="px-2 py-0.5 text-[10px] rounded bg-slate-800 text-slate-400">
                                 {car}
                             </span>
                         ))}
@@ -633,7 +633,7 @@ export default function ModelLibrary() {
                             </div>
                             <select
                                 value={sortBy}
-                                onChange={(e) => setSortBy(e.target.value as any)}
+                                onChange={(e) => setSortBy(e.target.value)}
                                 className="
                                     appearance-none outline-none bg-transparent w-full
                                     pl-2 pr-10 py-2.5 text-sm font-medium text-white

--- a/hooks/useFuzzySearch.ts
+++ b/hooks/useFuzzySearch.ts
@@ -97,7 +97,7 @@ export function useFuzzySearch<T extends Record<string, unknown>>({
 
         // Sort results to prioritize exact acronym matches
         return results
-            .sort((a: any, b: any) => {
+            .sort((a: { item: T & { _acronym?: string } }, b: { item: T & { _acronym?: string } }) => {
                 const aIsExactAcronym = a.item._acronym === lowerQuery;
                 const bIsExactAcronym = b.item._acronym === lowerQuery;
 


### PR DESCRIPTION
## Summary
- Replace `any` types with proper types in ConfigWizard, LanguageSwitcher, ModelLibrary, and useFuzzySearch
- Escape apostrophe in wizard intro copy
- Disambiguate `testedOn` map keys by index to stop React duplicate-key warnings caused by repeated entries (e.g. "comma 4") in model data

## Why
`next build` was clean but `npx eslint .` reported 9 errors and the browser console surfaced `Encountered two children with the same key, 'comma 4'` on /models. This PR fixes both without behavior changes.

## Verified
- `npx tsc --noEmit` — clean
- `npx eslint .` — 0 errors (22 pre-existing warnings untouched)
- `npx next build` — all 12 routes build
- `next dev` — `/`, `/wizard`, `/models`, `/features` all return 200

## Notes for reviewer
The underlying `data/models.*.json` files contain literal duplicate `testedOn` entries. The React fix handles the symptom; deduping the JSON is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)