### PR TITLE
feat: add agent discovery support (RFC 8288, RFC 9727, WebMCP)

### DIFF
--- a/app/.well-known/api-catalog/route.ts
+++ b/app/.well-known/api-catalog/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+
+// RFC 9727 API Catalog — application/linkset+json
+// Describes the Sunnylink Wiki's content sections and discovery endpoints
+const catalog = {
+  linkset: [
+    {
+      anchor: 'https://www.sunnylink.wiki/',
+      'service-doc': [
+        { href: 'https://www.sunnylink.wiki/features', type: 'text/html' },
+        { href: 'https://www.sunnylink.wiki/api/markdown?path=/', type: 'text/markdown' },
+      ],
+      describedby: [
+        { href: 'https://www.sunnylink.wiki/.well-known/api-catalog', type: 'application/linkset+json' },
+        { href: 'https://www.sunnylink.wiki/.well-known/agent-skills/index.json', type: 'application/json' },
+      ],
+    },
+    {
+      anchor: 'https://www.sunnylink.wiki/api/wiki-data',
+      'service-desc': [
+        { href: 'https://www.sunnylink.wiki/.well-known/api-catalog', type: 'application/linkset+json' },
+      ],
+      'service-doc': [
+        { href: 'https://www.sunnylink.wiki/features', type: 'text/html' },
+      ],
+      // Query parameters: type=(settings|models|cars), search=<query>, vibe=<vibe>, make=<make>, model=<model>
+    },
+    {
+      anchor: 'https://www.sunnylink.wiki/models',
+      'service-doc': [
+        { href: 'https://www.sunnylink.wiki/models', type: 'text/html' },
+        { href: 'https://www.sunnylink.wiki/api/markdown?path=/models', type: 'text/markdown' },
+      ],
+    },
+    {
+      anchor: 'https://www.sunnylink.wiki/cars',
+      'service-doc': [
+        { href: 'https://www.sunnylink.wiki/cars', type: 'text/html' },
+        { href: 'https://www.sunnylink.wiki/api/markdown?path=/cars', type: 'text/markdown' },
+      ],
+    },
+    {
+      anchor: 'https://www.sunnylink.wiki/features',
+      'service-doc': [
+        { href: 'https://www.sunnylink.wiki/features', type: 'text/html' },
+        { href: 'https://www.sunnylink.wiki/api/markdown?path=/features', type: 'text/markdown' },
+      ],
+    },
+  ],
+};
+
+export async function GET() {
+  return NextResponse.json(catalog, {
+    headers: {
+      'Content-Type': 'application/linkset+json',
+      'Cache-Control': 'public, max-age=86400, stale-while-revalidate=604800',
+    },
+  });
+}

--- a/app/api/markdown/route.ts
+++ b/app/api/markdown/route.ts
@@ -1,0 +1,170 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const PAGE_MARKDOWN: Record<string, string> = {
+  '/': `# Sunnylink Wiki
+
+> The complete reference for Sunnypilot — searchable settings, driving models, car compatibility, and features.
+
+## What is Sunnypilot?
+
+Sunnypilot is an open-source advanced driver assistance system (ADAS) built on top of comma.ai's openpilot platform. It adds community-driven features, expanded vehicle support, and additional driving models.
+
+## Main Sections
+
+- **[Settings Database](/)** — 100+ configurable toggles and parameters with descriptions, defaults, and community tips
+- **[Model Library](/models)** — Browse 82+ driving models, filterable by vibe (comfort, aggressive, WMI 2026, experimental)
+- **[Car Database](/cars)** — Vehicle-specific compatibility, recommended settings, and harness information
+- **[Feature Guide](/features)** — Detailed documentation for major Sunnypilot features (MADS, NNLC, Speed Limit Control, etc.)
+- **[Config Wizard](/wizard)** — Interactive tool to build a personalized Sunnypilot configuration
+- **[Live Stats](/stats)** — Real-time fleet statistics and model usage data
+
+## Key Features of Sunnypilot
+
+- **MADS (Modified Assistive Driving Safety)** — Decouples lateral and longitudinal control; keep ACC off while steering assist is active
+- **NNLC (Neural Network Lateral Control)** — AI-powered steering that adapts to your car's characteristics
+- **Speed Limit Control** — Automatically adjusts speed to posted limits using maps or vision
+- **Driving Models** — Swap between 82+ community-trained models tuned for different driving styles
+
+## Agent Discovery
+
+- API Catalog: \`/.well-known/api-catalog\`
+- MCP Server Card: \`/.well-known/mcp/server-card.json\`
+- Agent Skills: \`/.well-known/agent-skills/index.json\`
+`,
+  '/models': `# Sunnylink Model Library
+
+> Browse 82+ Sunnypilot driving models, each with a unique personality and tuning.
+
+## Model Vibes
+
+### WMI & 2026 World Series (Modern Standard)
+End-to-End intelligence. WMI V12 is the flagship for 2026. Best for daily driving including city streets, stop signs, and intersections.
+
+### Aggressive Series
+High-performance for heavy traffic. Dark Souls v2 excels with trucks and SUVs. Firehose is the bleeding-edge SOTA development feed.
+
+### Comfort & Smooth Series
+Passenger-friendly. Down to Ride (DTR) v6 is "wife-approved" — gentle braking, slow turns. Ideal for road trips.
+
+### Precision & Sport Series
+Tight, responsive steering. Perfect for drivers who want the car planted firmly in the center of the lane.
+
+### Experimental & Research
+Cutting-edge research models. May be unstable; for advanced testers only.
+
+## How to Choose
+
+1. **Daily city driving** → WMI V12
+2. **Truck/SUV in traffic** → Dark Souls v2
+3. **Passengers or road trips** → Down to Ride v6
+4. **Highway precision** → Precision Sport series
+5. **Testing latest tech** → Firehose
+
+Visit [sunnylink.wiki/models](/models) for the full interactive library with filtering.
+`,
+  '/features': `# Sunnylink Feature Guide
+
+> Detailed documentation for Sunnypilot's major features, enriched with community knowledge.
+
+## Major Features
+
+### MADS — Modified Assistive Driving Safety
+Decouples steering assist from adaptive cruise control. Lane keep active even when ACC is off.
+
+### NNLC — Neural Network Lateral Control
+AI-powered lateral control that learns your vehicle's steering characteristics for smoother, more natural inputs.
+
+### Speed Limit Control (SLC)
+Automatically adjusts vehicle speed to match posted speed limits. Sources: map data or vision-based sign detection.
+
+### Dynamic Experimental Mode
+Switches between openpilot's experimental E2E mode and classic mode based on road conditions.
+
+### Personality Profiles
+Quick-switch between preset driving personalities (Relaxed, Standard, Aggressive) that adjust following distance and acceleration.
+
+### Custom Alerts
+Configurable driver alerts for various conditions — speed, lane departure, following distance.
+
+Visit [sunnylink.wiki/features](/features) for the full feature guide.
+`,
+  '/cars': `# Sunnylink Car Database
+
+> Vehicle compatibility and recommended settings for Sunnypilot.
+
+## Supported Vehicles
+
+The Sunnylink Car Database covers vehicles compatible with Sunnypilot across major manufacturers including:
+
+- **Hyundai / Kia / Genesis** — Extensive support via HKG harnesses
+- **Toyota / Lexus** — Wide coverage with Toyota-specific harnesses
+- **Honda / Acura** — Supported via Honda Nidec/Bosch harnesses
+- **GM (Chevrolet, GMC, Cadillac, Buick)** — OBD-II based support
+- **Subaru** — Global-B harness
+- **Volkswagen / Audi / Seat / Skoda** — J533 harness
+- **Nissan / Infiniti** — Nissan harness variants
+
+## What the Database Provides
+
+For each vehicle:
+- Required hardware (device type, harness, radar)
+- Best settings (recommended driving model, torque tuning, lateral/longitudinal control)
+- Multiple configuration presets (smooth highway, performance, comfort)
+- Community consensus ratings
+
+Visit [sunnylink.wiki/cars](/cars) to search the full database.
+`,
+  '/wizard': `# Sunnylink Config Wizard
+
+> Interactive tool to build a personalized Sunnypilot configuration.
+
+## What the Wizard Does
+
+The Config Wizard guides you through selecting the optimal Sunnypilot settings for your vehicle, driving style, and use case. It asks questions about:
+
+1. **Your vehicle** — Make, model, year
+2. **Driving environment** — Mostly highway, city, or mixed
+3. **Passenger considerations** — Solo driving or passengers who get motion sick
+4. **Experience level** — New to sunnypilot or experienced user
+5. **Preferences** — Tight lane centering vs. relaxed, aggressive vs. gentle
+
+At the end, it recommends a specific driving model, key toggle settings, and tuning parameters.
+
+Visit [sunnylink.wiki/wizard](/wizard) to start the wizard.
+`,
+  '/stats': `# Sunnylink Live Stats
+
+> Real-time fleet statistics for the Sunnypilot community.
+
+## What Stats Are Tracked
+
+- Active fleet size (number of devices running Sunnypilot)
+- Most popular driving models in use
+- Model distribution by geography
+- Recent model adoption trends
+
+Stats are updated in real-time and reflect the global Sunnypilot community.
+
+Visit [sunnylink.wiki/stats](/stats) for live data.
+`,
+};
+
+function estimateTokens(text: string): number {
+  // Rough estimate: ~4 chars per token (GPT-style BPE approximation)
+  return Math.ceil(text.length / 4);
+}
+
+export async function GET(request: NextRequest) {
+  const path = request.nextUrl.searchParams.get('path') ?? '/';
+  const content = PAGE_MARKDOWN[path] ?? PAGE_MARKDOWN['/'];
+  const tokens = estimateTokens(content);
+
+  return new NextResponse(content, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Vary': 'Accept',
+      'x-markdown-tokens': String(tokens),
+      'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+    },
+  });
+}

--- a/app/api/wiki-data/route.ts
+++ b/app/api/wiki-data/route.ts
@@ -1,0 +1,134 @@
+import { NextRequest, NextResponse } from 'next/server';
+import togglesData from '@/data/toggles.json';
+import modelsData from '@/data/models.json';
+import carsData from '@/data/cars.json';
+
+type Toggle = {
+  key: string;
+  label: string;
+  description?: string;
+  type?: string;
+  default?: unknown;
+  useCase?: string;
+};
+
+type Category = {
+  id: string;
+  name: string;
+  settings: Toggle[];
+};
+
+type Model = {
+  name: string;
+  vibe?: string;
+  description?: string;
+  bestFor?: string;
+  [key: string]: unknown;
+};
+
+type Vehicle = {
+  id: string;
+  make: string;
+  model: string;
+  years?: string;
+  bestSettings?: Record<string, string>;
+  [key: string]: unknown;
+};
+
+function searchSettings(query: string) {
+  const q = query.toLowerCase();
+  const results: Array<{ key: string; label: string; description: string; category: string; type: string; default: unknown }> = [];
+
+  for (const category of (togglesData as { categories: Category[] }).categories) {
+    for (const setting of category.settings) {
+      const matchesLabel = setting.label?.toLowerCase().includes(q);
+      const matchesKey = setting.key?.toLowerCase().includes(q);
+      const matchesDesc = setting.description?.toLowerCase().includes(q);
+      const matchesUseCase = setting.useCase?.toLowerCase().includes(q);
+
+      if (matchesLabel || matchesKey || matchesDesc || matchesUseCase) {
+        results.push({
+          key: setting.key,
+          label: setting.label,
+          description: setting.description ?? '',
+          category: category.name,
+          type: setting.type ?? 'toggle',
+          default: setting.default,
+        });
+      }
+    }
+  }
+
+  return results.slice(0, 10);
+}
+
+function searchModels(query?: string, vibe?: string) {
+  const models = (modelsData as { models?: Model[]; vibeGuide?: Record<string, { title: string; vibe: string; bestFor: string; recommendation?: string }> });
+  const vibeGuide = models.vibeGuide ?? {};
+
+  if (vibe) {
+    const guide = vibeGuide[vibe];
+    if (guide) {
+      return {
+        vibe,
+        title: guide.title,
+        description: guide.vibe,
+        bestFor: guide.bestFor,
+        recommendation: guide.recommendation,
+      };
+    }
+    return { error: `Vibe '${vibe}' not found. Available vibes: ${Object.keys(vibeGuide).join(', ')}` };
+  }
+
+  // Return vibe guide summary
+  return Object.entries(vibeGuide).map(([id, g]) => ({
+    id,
+    title: g.title,
+    bestFor: g.bestFor,
+  }));
+}
+
+function searchCars(make?: string, model?: string) {
+  const vehicles = (carsData as { vehicles: Vehicle[] }).vehicles;
+  const q_make = make?.toLowerCase();
+  const q_model = model?.toLowerCase();
+
+  const results = vehicles.filter(v => {
+    const makeMatch = !q_make || v.make.toLowerCase().includes(q_make);
+    const modelMatch = !q_model || v.model.toLowerCase().includes(q_model);
+    return makeMatch && modelMatch;
+  });
+
+  return results.slice(0, 5).map(v => ({
+    id: v.id,
+    make: v.make,
+    model: v.model,
+    years: v.years,
+    bestSettings: v.bestSettings,
+  }));
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const type = searchParams.get('type') ?? 'settings';
+  const query = searchParams.get('search') ?? searchParams.get('query') ?? '';
+  const vibe = searchParams.get('vibe') ?? undefined;
+  const make = searchParams.get('make') ?? undefined;
+  const model = searchParams.get('model') ?? undefined;
+
+  let data;
+  switch (type) {
+    case 'models':
+      data = searchModels(query || undefined, vibe);
+      break;
+    case 'cars':
+      data = searchCars(make, model);
+      break;
+    default:
+      data = query ? searchSettings(query) : { error: 'Provide a search query' };
+  }
+
+  return NextResponse.json({ type, results: data }, {
+    headers: { 'Cache-Control': 'public, max-age=300' },
+  });
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import BottomNav from '@/components/BottomNav';
 import UniversalSearch from '@/components/UniversalSearch';
 import GlobalControls from '@/components/GlobalControls';
 import { LanguageProvider } from '@/lib/i18n';
+import WebMCP from '@/components/WebMCP';
 
 const inter = Inter({
   subsets: ["latin"],
@@ -83,6 +84,7 @@ export default function RootLayout({
           <GlobalControls />
           <UniversalSearch />
           <BottomNav />
+          <WebMCP />
         </LanguageProvider>
       </body>
     </html>

--- a/components/WebMCP.tsx
+++ b/components/WebMCP.tsx
@@ -1,0 +1,99 @@
+'use client';
+import { useEffect } from 'react';
+
+// WebMCP API type — experimental browser API (https://webmachinelearning.github.io/webmcp/)
+type WebMCPTool = {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute: (params: Record<string, string>) => Promise<unknown>;
+};
+
+type ModelContextNavigator = Navigator & {
+  modelContext?: {
+    provideContext: (options: { tools: WebMCPTool[] }) => void;
+  };
+};
+
+export default function WebMCP() {
+  useEffect(() => {
+    const nav = navigator as ModelContextNavigator;
+    if (!nav.modelContext?.provideContext) return;
+
+    nav.modelContext.provideContext({
+      tools: [
+        {
+          name: 'search_settings',
+          description:
+            'Search the Sunnylink Wiki for Sunnypilot settings and toggles. Returns matching settings with descriptions, defaults, use cases, and community tips.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              query: {
+                type: 'string',
+                description: 'Search keyword (e.g. "camera offset", "MADS", "speed limit", "lane change")',
+              },
+            },
+            required: ['query'],
+          },
+          execute: async ({ query }) => {
+            const res = await fetch(`/api/wiki-data?type=settings&search=${encodeURIComponent(query)}`);
+            return res.json();
+          },
+        },
+        {
+          name: 'browse_models',
+          description:
+            'Browse Sunnypilot driving models. Filter by vibe category (wmi_2026, aggressive, comfort, precision, experimental) or search by model name.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              vibe: {
+                type: 'string',
+                description: 'Vibe category: wmi_2026, aggressive, comfort, precision, experimental',
+              },
+              query: {
+                type: 'string',
+                description: 'Search by model name (e.g. "WMI V12", "Down to Ride", "Dark Souls")',
+              },
+            },
+          },
+          execute: async ({ vibe, query }) => {
+            const params = new URLSearchParams({ type: 'models' });
+            if (vibe) params.set('vibe', vibe);
+            if (query) params.set('search', query);
+            const res = await fetch(`/api/wiki-data?${params}`);
+            return res.json();
+          },
+        },
+        {
+          name: 'check_car',
+          description:
+            'Check if a car make/model is compatible with Sunnypilot. Returns required hardware (device, harness, radar), best settings, and configuration presets.',
+          inputSchema: {
+            type: 'object',
+            properties: {
+              make: {
+                type: 'string',
+                description: 'Car manufacturer (e.g. Toyota, Honda, Hyundai, Kia, Subaru)',
+              },
+              model: {
+                type: 'string',
+                description: 'Car model (e.g. Camry, Civic, Ioniq 5, Sonata)',
+              },
+            },
+          },
+          execute: async ({ make, model }) => {
+            const params = new URLSearchParams({ type: 'cars' });
+            if (make) params.set('make', make);
+            if (model) params.set('model', model);
+            const res = await fetch(`/api/wiki-data?${params}`);
+            return res.json();
+          },
+        },
+      ],
+    });
+  }, []);
+
+  return null;
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,36 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+const ROBOTS_CONTENT = `User-agent: *
+Allow: /
+
+Content-Signal: ai-train=no, search=yes, ai-input=no
+
+Sitemap: https://www.sunnylink.wiki/sitemap.xml
+`;
+
+// Pages that support text/markdown content negotiation
+const MARKDOWN_PAGES = new Set(['/', '/models', '/features', '/cars', '/wizard', '/stats']);
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Serve custom robots.txt with Content-Signal directives (contentsignals.org)
+  if (pathname === '/robots.txt') {
+    return new NextResponse(ROBOTS_CONTENT, {
+      headers: { 'Content-Type': 'text/plain; charset=utf-8' },
+    });
+  }
+
+  // RFC 8288 / Cloudflare Markdown for Agents: return markdown when requested
+  const accept = request.headers.get('accept') ?? '';
+  if (MARKDOWN_PAGES.has(pathname) && accept.includes('text/markdown')) {
+    const url = request.nextUrl.clone();
+    url.pathname = '/api/markdown';
+    url.searchParams.set('path', pathname);
+    return NextResponse.rewrite(url);
+  }
+}
+
+export const config = {
+  matcher: ['/robots.txt', '/', '/models', '/features', '/cars', '/wizard', '/stats'],
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,32 @@ const nextConfig: NextConfig = {
   // (Array.prototype.at, Object.hasOwn, String.prototype.trimEnd, etc.)
   // saving ~13.4 KiB
   transpilePackages: [],
+  async headers() {
+    return [
+      {
+        // RFC 8288 Link headers on the homepage for agent discovery
+        source: '/',
+        headers: [
+          {
+            key: 'Link',
+            value: [
+              '</.well-known/api-catalog>; rel="api-catalog"',
+              '</.well-known/agent-skills/index.json>; rel="describedby"; type="application/json"',
+              '</.well-known/mcp/server-card.json>; rel="describedby"; type="application/json"',
+              '</api/markdown>; rel="alternate"; type="text/markdown"',
+            ].join(', '),
+          },
+        ],
+      },
+      {
+        // Advertise content negotiation support on all main pages
+        source: '/(|models|features|cars|wizard|stats)',
+        headers: [
+          { key: 'Vary', value: 'Accept' },
+        ],
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/public/.well-known/agent-skills/browse-models.json
+++ b/public/.well-known/agent-skills/browse-models.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://agentskills.io/schema/v0.2/skill.json",
+  "name": "browse-driving-models",
+  "version": "1.0.0",
+  "type": "webmcp",
+  "description": "Browse the Sunnylink Wiki library of 82+ Sunnypilot driving models. Filter by vibe (comfort, aggressive, WMI 2026, experimental, precision) or search by name to find the best model for your driving style.",
+  "tools": [
+    {
+      "name": "browse_models",
+      "description": "Get information about Sunnypilot driving models. Filter by vibe category or search by name.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "vibe": {
+            "type": "string",
+            "description": "Filter by vibe: wmi_2026, aggressive, comfort, precision, experimental"
+          },
+          "query": {
+            "type": "string",
+            "description": "Search by model name (e.g. 'WMI V12', 'Down to Ride', 'Dark Souls')"
+          }
+        }
+      }
+    }
+  ],
+  "endpoints": {
+    "data": "https://www.sunnylink.wiki/api/wiki-data?type=models&vibe={vibe}"
+  }
+}

--- a/public/.well-known/agent-skills/check-car-compatibility.json
+++ b/public/.well-known/agent-skills/check-car-compatibility.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://agentskills.io/schema/v0.2/skill.json",
+  "name": "check-car-compatibility",
+  "version": "1.0.0",
+  "type": "webmcp",
+  "description": "Check if a specific car make and model is compatible with Sunnypilot. Returns required hardware (device, harness, radar), best settings, and multiple configuration presets from the community.",
+  "tools": [
+    {
+      "name": "check_car",
+      "description": "Check car compatibility with Sunnypilot. Provide make and/or model to get compatibility status and recommended settings.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "make": {
+            "type": "string",
+            "description": "Car manufacturer (e.g. Toyota, Honda, Hyundai, Kia, Subaru, GM, Volkswagen)"
+          },
+          "model": {
+            "type": "string",
+            "description": "Car model (e.g. Camry, Civic, Ioniq 5, Sonata, Outback)"
+          }
+        }
+      }
+    }
+  ],
+  "endpoints": {
+    "data": "https://www.sunnylink.wiki/api/wiki-data?type=cars&make={make}&model={model}"
+  }
+}

--- a/public/.well-known/agent-skills/index.json
+++ b/public/.well-known/agent-skills/index.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://agentskills.io/schema/v0.2/index.json",
+  "name": "Sunnylink Wiki Agent Skills",
+  "description": "Agent-discoverable skills for the Sunnylink Wiki — the complete Sunnypilot reference covering settings, driving models, and car compatibility.",
+  "version": "0.2.0",
+  "skills": [
+    {
+      "name": "search-sunnypilot-settings",
+      "type": "webmcp",
+      "description": "Search 100+ Sunnypilot settings, toggles, and configuration parameters with descriptions, defaults, and community tips.",
+      "url": "https://www.sunnylink.wiki/.well-known/agent-skills/search-settings.json",
+      "digest": {
+        "sha256": "5f432ecaa28abd7a47a30d2cd40ddc0b3513ae1626636e5099a57e6eab859dca"
+      }
+    },
+    {
+      "name": "browse-driving-models",
+      "type": "webmcp",
+      "description": "Browse 82+ Sunnypilot driving models filtered by vibe (comfort, aggressive, WMI 2026, experimental) or name.",
+      "url": "https://www.sunnylink.wiki/.well-known/agent-skills/browse-models.json",
+      "digest": {
+        "sha256": "4734f1d2176e6864f463d047ae9ae1e8307cf6bd8a769ed6c3f4335e8446a136"
+      }
+    },
+    {
+      "name": "check-car-compatibility",
+      "type": "webmcp",
+      "description": "Check if a car make/model is compatible with Sunnypilot and get required hardware and recommended settings.",
+      "url": "https://www.sunnylink.wiki/.well-known/agent-skills/check-car-compatibility.json",
+      "digest": {
+        "sha256": "54189c170b7acfa0b009f068cdaf1baa5f5c06461507bedb59c2ce676c6e5645"
+      }
+    }
+  ]
+}

--- a/public/.well-known/agent-skills/search-settings.json
+++ b/public/.well-known/agent-skills/search-settings.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://agentskills.io/schema/v0.2/skill.json",
+  "name": "search-sunnypilot-settings",
+  "version": "1.0.0",
+  "type": "webmcp",
+  "description": "Search the Sunnylink Wiki database of 100+ Sunnypilot settings, toggles, and configuration parameters. Returns matching settings with descriptions, default values, use cases, and community tips.",
+  "tools": [
+    {
+      "name": "search_settings",
+      "description": "Search for Sunnypilot settings by keyword. Returns matching settings with full descriptions, defaults, and usage notes.",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Search keyword or phrase (e.g. 'camera offset', 'speed limit', 'MADS', 'lane change')"
+          }
+        },
+        "required": ["query"]
+      }
+    }
+  ],
+  "endpoints": {
+    "data": "https://www.sunnylink.wiki/api/wiki-data?type=settings&search={query}"
+  }
+}

--- a/public/.well-known/mcp/server-card.json
+++ b/public/.well-known/mcp/server-card.json
@@ -1,0 +1,55 @@
+{
+  "serverInfo": {
+    "name": "Sunnylink Wiki",
+    "version": "1.0.0",
+    "description": "MCP-compatible interface for the Sunnylink Wiki — the complete reference for Sunnypilot settings, driving models, car compatibility, and features."
+  },
+  "transport": {
+    "type": "http",
+    "endpoint": "https://www.sunnylink.wiki/api/wiki-data"
+  },
+  "capabilities": {
+    "tools": true,
+    "resources": true,
+    "prompts": false
+  },
+  "tools": [
+    {
+      "name": "search_settings",
+      "description": "Search Sunnypilot settings and toggles by keyword",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "query": { "type": "string", "description": "Search keyword (e.g. 'camera offset', 'MADS', 'speed limit')" }
+        },
+        "required": ["query"]
+      }
+    },
+    {
+      "name": "browse_models",
+      "description": "Browse Sunnypilot driving models by vibe or name",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "vibe": { "type": "string", "description": "Vibe category: wmi_2026, aggressive, comfort, precision, experimental" },
+          "query": { "type": "string", "description": "Search by model name" }
+        }
+      }
+    },
+    {
+      "name": "check_car",
+      "description": "Check if a car make/model is compatible with Sunnypilot and get recommended settings",
+      "inputSchema": {
+        "type": "object",
+        "properties": {
+          "make": { "type": "string", "description": "Car manufacturer (e.g. Toyota, Honda, Hyundai)" },
+          "model": { "type": "string", "description": "Car model (e.g. Camry, Civic, Ioniq 5)" }
+        }
+      }
+    }
+  ],
+  "contact": {
+    "url": "https://www.sunnylink.wiki",
+    "community": "https://community.sunnypilot.ai"
+  }
+}


### PR DESCRIPTION
- Link response headers on homepage pointing to api-catalog, agent-skills, MCP server card, and markdown alternate (RFC 8288)
- middleware.ts: custom robots.txt with Content-Signal directives (ai-train=no, search=yes, ai-input=no) and markdown content negotiation (Accept: text/markdown → /api/markdown)
- app/api/markdown/route.ts: serves text/markdown responses with Content-Type: text/markdown and x-markdown-tokens header
- app/api/wiki-data/route.ts: searchable API for settings, models, and car compatibility data (powers WebMCP tools)
- app/.well-known/api-catalog/route.ts: RFC 9727 API catalog returning application/linkset+json
- public/.well-known/mcp/server-card.json: MCP Server Card (SEP-1649) with tool definitions
- public/.well-known/agent-skills/: agent skills discovery index with sha256 digests + skill definition files for search-settings, browse-models, check-car-compatibility
- components/WebMCP.tsx: WebMCP navigator.modelContext.provideContext() with three tools wired to /api/wiki-data

https://claude.ai/code/session_01JKnuTVrCP2fuaio3GoEAbH