### PR TITLE
fix: hide Dashboard button after scroll on all pages

### DIFF
--- a/components/GlobalControls.tsx
+++ b/components/GlobalControls.tsx
@@ -11,7 +11,6 @@ export default function GlobalControls() {
     const { t } = useLanguage();
     const pathname = usePathname();
     const isWizard = pathname === '/wizard';
-    const isSettings = pathname === '/';
     const [sidebarSticky, setSidebarSticky] = useState(false);
     const [scrolledPastHeader, setScrolledPastHeader] = useState(false);
 
@@ -54,7 +53,7 @@ export default function GlobalControls() {
             <div className={`
                 absolute top-4 right-4 sm:top-8 sm:right-8 flex items-center gap-4 pointer-events-auto
                 transition-opacity duration-200 ease-out
-                ${(isSettings && scrolledPastHeader) ? 'opacity-0 pointer-events-none' : 'opacity-100'}
+                ${scrolledPastHeader ? 'opacity-0 pointer-events-none' : 'opacity-100'}
             `}>
                 <a
                     href="https://www.sunnylink.ai/dashboard"


### PR DESCRIPTION
## Summary
- Follow-up to #47. The Dashboard button (fixed top-right) was only hidden after scroll on the home page (`isSettings`). On Models/Cars/Stats/Features it stayed pinned and visually overlapped the right side of cards, making padding look asymmetric vs the Settings page.
- Dropping the `isSettings` guard makes every page behave like Settings: scroll past the header → button fades out → cards have balanced 16px left/right padding.

## Test plan
- [ ] Models page at 375px: scroll down → Dashboard button hides, cards have symmetric padding
- [ ] Settings page: behavior unchanged
- [ ] Top of any page (scrollY=0): Dashboard button still visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)