### PR TITLE
fix: keep mobile vibe guide open while scrolling on iOS

### DIFF
--- a/components/ModelLibrary.tsx
+++ b/components/ModelLibrary.tsx
@@ -493,6 +493,11 @@ export default function ModelLibrary() {
     }, []);
 
     const effectiveIsSticky = isSticky || isSearchActive;
+    // While the user has an expanded section open (Vibe Guide or Categories),
+    // don't collapse/pin the mobile filters wrapper — collapsing mid-scroll
+    // shrinks the page and snaps the viewport down into "All Models",
+    // making the guide unreadable on iOS.
+    const stickyCollapseActive = effectiveIsSticky && !showVibeGuide && !showMobileCategories;
 
     return (
         <div className="lg:flex lg:gap-8">
@@ -591,7 +596,7 @@ export default function ModelLibrary() {
                 <div ref={sentinelRef} className="lg:hidden h-0" />
 
                 {/* Mobile Filters - Sticky only after scrolling past natural position */}
-                <div className={`lg:hidden -mx-4 px-4 pt-2 pb-4 space-y-4 mb-6 transition-all duration-300 relative ${effectiveIsSticky ? 'sticky top-16 z-20' : ''}`}>
+                <div className={`lg:hidden -mx-4 px-4 pt-2 pb-4 space-y-4 mb-6 transition-all duration-300 relative ${stickyCollapseActive ? 'sticky top-16 z-20' : ''}`}>
                     <SearchFilter
                         value={searchQuery}
                         onChange={setSearchQuery}
@@ -600,7 +605,7 @@ export default function ModelLibrary() {
                         itemLabel="models"
                     />
 
-                    <div className={`transition-all duration-300 overflow-hidden ${effectiveIsSticky ? 'max-h-0 opacity-0 pointer-events-none' : 'max-h-[2000px] opacity-100'}`}>
+                    <div className={`transition-all duration-300 overflow-hidden ${stickyCollapseActive ? 'max-h-0 opacity-0 pointer-events-none' : 'max-h-[2000px] opacity-100'}`}>
                         <div className="space-y-4 pt-2">
                             <button
                                 onClick={() => setShowVibeGuide(!showVibeGuide)}


### PR DESCRIPTION
The mobile filters wrapper collapsed its inner container (Vibe Guide
content + Categories) to max-h-0 the moment effectiveIsSticky flipped
true. Since the sticky sentinel sits at the top of the main content
area, scrolling down to read an opened Vibe Guide instantly shrunk the
page, and the model grid below jumped up into the viewport — landing
the user inside "All Models" with the guide gone.

Skip the sticky-collapse path while either expandable section is open
so the user can scroll naturally through the content. Sticky behavior
resumes once the section is closed.