### PR TITLE
Donate modal GA events + weekly forum activity sync on model cards

### DIFF
--- a/app/models/page.tsx
+++ b/app/models/page.tsx
@@ -2,6 +2,11 @@ import PageShell from '@/components/PageShell';
 import ModelLibrary from '@/components/ModelLibrary';
 import type { Metadata } from 'next';
 import modelsData from '@/data/models.json';
+import { fetchModelForumActivity, type ForumActivityMap } from '@/lib/discourse-models-sync';
+
+// Weekly sync of forum vote/comment activity onto each model card.
+// Pairs with the per-fetch revalidate inside lib/discourse-models-sync.
+export const revalidate = 60 * 60 * 24 * 7; // 7 days
 
 // ──────────────────────────────────────────────────────────────────────
 // SEO target: capture searches for "openpilot models" / "comma.ai
@@ -163,7 +168,24 @@ const webPageLd = {
     },
 };
 
-export default function ModelsPage() {
+function collectForumUrls(): string[] {
+    const urls: string[] = [];
+    for (const category of modelsData.categories as { models: { forumUrl?: string }[] }[]) {
+        for (const m of category.models) {
+            if (m.forumUrl) urls.push(m.forumUrl);
+        }
+    }
+    return urls;
+}
+
+export default async function ModelsPage() {
+    let forumActivity: ForumActivityMap = {};
+    try {
+        forumActivity = await fetchModelForumActivity(collectForumUrls());
+    } catch (err) {
+        console.error('[models page] forum activity fetch failed:', err);
+    }
+
     return (
         <PageShell>
             <div>
@@ -179,7 +201,7 @@ export default function ModelsPage() {
                 </header>
 
                 <section id="openpilot-models-library" aria-label="openpilot models database">
-                    <ModelLibrary />
+                    <ModelLibrary forumActivity={forumActivity} />
                 </section>
 
                 {/* Long-form FAQ — visible content, matched 1:1 by the FAQPage

--- a/components/ModelLibrary.tsx
+++ b/components/ModelLibrary.tsx
@@ -16,6 +16,14 @@ import { useStickySearch } from '../hooks/useStickySearch';
 import { useDesktopSidebarSticky } from '../hooks/useDesktopSidebarSticky';
 import { useLanguage } from '../lib/i18n';
 import { useTranslatedModels } from '../lib/useTranslatedData';
+import type { ForumActivity, ForumActivityMap } from '../lib/discourse-models-sync';
+
+function extractTopicId(forumUrl: string): number | null {
+    const m = forumUrl.match(/\/t\/(?:[^/]+\/)?(\d+)(?:[/?#]|$)/);
+    if (!m) return null;
+    const id = Number(m[1]);
+    return Number.isFinite(id) ? id : null;
+}
 
 const CategorySidebarButton = dynamic(() => import('./CategorySidebarButton'), { ssr: false });
 
@@ -71,8 +79,85 @@ function SentimentBar({ sentiment }: { sentiment: SentimentData }) {
     );
 }
 
+function relativeTime(iso: string): string {
+    const then = new Date(iso).getTime();
+    if (!Number.isFinite(then)) return '';
+    const diff = Date.now() - then;
+    const mins = Math.round(diff / 60000);
+    if (mins < 60) return `${Math.max(1, mins)}m ago`;
+    const hrs = Math.round(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    const days = Math.round(hrs / 24);
+    if (days < 30) return `${days}d ago`;
+    const months = Math.round(days / 30);
+    if (months < 12) return `${months}mo ago`;
+    return `${Math.round(months / 12)}y ago`;
+}
+
+function ForumActivityPanel({ activity, forumUrl }: { activity: ForumActivity; forumUrl: string }) {
+    return (
+        <div className="mt-3 pt-3 border-t border-slate-700/50">
+            <div className="flex items-center justify-between mb-2">
+                <p className="text-xs text-slate-500 flex items-center gap-3">
+                    <span className="inline-flex items-center gap-1" title="Likes on the original post (community votes)">
+                        <span aria-hidden>❤️</span>
+                        <span className="text-slate-300 font-medium">{activity.voteCount}</span>
+                        <span>votes</span>
+                    </span>
+                    <span className="inline-flex items-center gap-1">
+                        <span aria-hidden>💬</span>
+                        <span className="text-slate-300 font-medium">{activity.replyCount}</span>
+                        <span>replies</span>
+                    </span>
+                    {activity.lastPostedAt && (
+                        <span className="hidden sm:inline">active {relativeTime(activity.lastPostedAt)}</span>
+                    )}
+                </p>
+                <span className="text-[10px] text-slate-600 uppercase tracking-wider">synced weekly</span>
+            </div>
+
+            {activity.recentComments.length > 0 && (
+                <ul className="space-y-2">
+                    {activity.recentComments.map((c) => (
+                        <li key={c.postNumber} className="text-xs">
+                            <a
+                                href={`${forumUrl.replace(/\/$/, '')}/${c.postNumber}`}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                onClick={(e) => e.stopPropagation()}
+                                className="block rounded-lg bg-slate-800/40 hover:bg-slate-800/70 border border-slate-700/40 px-2.5 py-2 transition-colors"
+                            >
+                                <div className="flex items-center gap-2 mb-0.5">
+                                    <span className="text-cyan-300 font-medium truncate">
+                                        @{c.username}
+                                    </span>
+                                    <span className="text-slate-500">{relativeTime(c.createdAt)}</span>
+                                    {c.likeCount > 0 && (
+                                        <span className="ml-auto text-slate-500">❤️ {c.likeCount}</span>
+                                    )}
+                                </div>
+                                <p className="text-slate-300 leading-snug line-clamp-2 break-words">
+                                    {c.snippet}
+                                </p>
+                            </a>
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
+    );
+}
+
 // Model Card Component
-function ModelCard({ model, onExpand }: { model: Model; onExpand?: (modelName: string) => void }) {
+function ModelCard({
+    model,
+    onExpand,
+    forumActivity,
+}: {
+    model: Model;
+    onExpand?: (modelName: string) => void;
+    forumActivity?: ForumActivity;
+}) {
     const [copied, setCopied] = useState(false);
 
     const handleCopyLink = async (e: React.MouseEvent) => {
@@ -289,6 +374,12 @@ function ModelCard({ model, onExpand }: { model: Model; onExpand?: (modelName: s
                     </div>
                 </div>
             )}
+
+            {/* Forum activity — votes (OP likes) + most recent comments,
+                synced weekly from community.sunnypilot.ai. */}
+            {forumActivity && model.forumUrl && (
+                <ForumActivityPanel activity={forumActivity} forumUrl={model.forumUrl} />
+            )}
             </div>
         </div>
     );
@@ -367,7 +458,7 @@ const getVibeIcon = (consensus?: string) => {
     }
 };
 
-export default function ModelLibrary() {
+export default function ModelLibrary({ forumActivity }: { forumActivity?: ForumActivityMap } = {}) {
     const [activeCategory, setActiveCategory] = useState<string>('all');
     const [showVibeGuide, setShowVibeGuide] = useState(false);
     const [showMobileCategories, setShowMobileCategories] = useState(false);
@@ -883,13 +974,17 @@ export default function ModelLibrary() {
                                 exit={{ opacity: 0 }}
                                 className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-2"
                             >
-                                {activeModels.map((model) => (
-                                    <div key={model.name} className="h-full">
-                                        <LazyModelCard>
-                                            <ModelCard model={model} onExpand={setVisualizerModelName} />
-                                        </LazyModelCard>
-                                    </div>
-                                ))}
+                                {activeModels.map((model) => {
+                                    const topicId = model.forumUrl ? extractTopicId(model.forumUrl) : null;
+                                    const activity = topicId && forumActivity ? forumActivity[topicId] : undefined;
+                                    return (
+                                        <div key={model.name} className="h-full">
+                                            <LazyModelCard>
+                                                <ModelCard model={model} onExpand={setVisualizerModelName} forumActivity={activity} />
+                                            </LazyModelCard>
+                                        </div>
+                                    );
+                                })}
                             </motion.div>
                         )}
                     </AnimatePresence>

--- a/components/SessionDonateModal.tsx
+++ b/components/SessionDonateModal.tsx
@@ -11,6 +11,14 @@ const TRIGGER_MS = 5 * 60 * 1000;
 const COOLDOWN_MS = 30 * 24 * 60 * 60 * 1000;
 const BMC_URL = 'https://buymeacoffee.com/vinhle.co';
 
+const trackEvent = (action: string, params: Record<string, unknown> = {}) => {
+    if (typeof window === 'undefined') return;
+    const gtag = (window as unknown as { gtag?: (...args: unknown[]) => void }).gtag;
+    if (typeof gtag === 'function') {
+        gtag('event', action, params);
+    }
+};
+
 export default function SessionDonateModal() {
     const [open, setOpen] = useState(false);
     const [mounted, setMounted] = useState(false);
@@ -30,15 +38,21 @@ export default function SessionDonateModal() {
         } catch {
             // localStorage can throw in private modes — fall through and just show normally.
         }
-        const handle = window.setTimeout(() => setOpen(true), TRIGGER_MS);
+        const handle = window.setTimeout(() => {
+            setOpen(true);
+            trackEvent('donate_modal_shown', { trigger_ms: TRIGGER_MS });
+        }, TRIGGER_MS);
         return () => window.clearTimeout(handle);
     }, []);
 
-    const dismiss = () => {
+    const dismiss = (method: 'backdrop' | 'escape' | 'no_thanks' | 'cta' = 'backdrop') => {
         try {
             window.localStorage.setItem(LS_KEY, String(Date.now()));
         } catch {
             // ignore
+        }
+        if (method !== 'cta') {
+            trackEvent('donate_modal_dismissed', { method });
         }
         setOpen(false);
     };
@@ -47,7 +61,7 @@ export default function SessionDonateModal() {
     useEffect(() => {
         if (!open) return;
         const onKey = (e: KeyboardEvent) => {
-            if (e.key === 'Escape') dismiss();
+            if (e.key === 'Escape') dismiss('escape');
         };
         window.addEventListener('keydown', onKey);
         const prev = document.body.style.overflow;
@@ -63,7 +77,7 @@ export default function SessionDonateModal() {
     return createPortal(
         <div
             className="fixed inset-0 z-[200] flex items-center justify-center p-4 bg-black/65 backdrop-blur-sm animate-in fade-in duration-200"
-            onClick={dismiss}
+            onClick={() => dismiss('backdrop')}
         >
             <div
                 role="dialog"
@@ -87,7 +101,10 @@ export default function SessionDonateModal() {
                     href={BMC_URL}
                     target="_blank"
                     rel="noopener noreferrer"
-                    onClick={dismiss}
+                    onClick={() => {
+                        trackEvent('donate_modal_clicked', { destination: BMC_URL });
+                        dismiss('cta');
+                    }}
                     className="block w-full text-center font-bold py-3 px-5 rounded-xl bg-[#FFDD00] hover:bg-[#ffe84d] active:bg-[#e6c700] text-slate-900 transition-colors shadow-md"
                 >
                     ☕ Buy me a coffee
@@ -95,7 +112,7 @@ export default function SessionDonateModal() {
 
                 <button
                     type="button"
-                    onClick={dismiss}
+                    onClick={() => dismiss('no_thanks')}
                     className="block mx-auto mt-4 text-xs text-slate-500 hover:text-slate-300 transition-colors"
                 >
                     No thanks

--- a/lib/discourse-models-sync.ts
+++ b/lib/discourse-models-sync.ts
@@ -1,0 +1,190 @@
+/**
+ * Server-side Discourse sync for per-model topic activity.
+ *
+ * Each entry in data/models.json carries a forumUrl pointing at a
+ * specific topic on community.sunnypilot.ai. This module pulls
+ * vote/comment activity for those topics and exposes a serializable
+ * snapshot the models page can render.
+ *
+ * Caches via Next.js fetch revalidation (7 days) — pairs with the
+ * `export const revalidate = 604800` declaration on the models route.
+ */
+
+const DISCOURSE_BASE = 'https://community.sunnypilot.ai';
+const REVALIDATE_SECONDS = 7 * 24 * 60 * 60; // 7 days
+const BATCH_SIZE = 6;
+const BATCH_DELAY_MS = 250;
+const RECENT_COMMENTS = 3;
+const SNIPPET_CHARS = 220;
+
+export interface ForumComment {
+    postNumber: number;
+    username: string;
+    displayName: string | null;
+    createdAt: string;
+    likeCount: number;
+    snippet: string;
+}
+
+export interface ForumActivity {
+    topicId: number;
+    voteCount: number; // likes on the OP (post_number === 1)
+    replyCount: number; // posts_count excluding the OP
+    lastPostedAt: string | null;
+    recentComments: ForumComment[];
+}
+
+export type ForumActivityMap = Record<number, ForumActivity>;
+
+/** Extract the numeric topic ID from a community.sunnypilot.ai URL. */
+export function extractTopicId(forumUrl: string): number | null {
+    if (!forumUrl) return null;
+    // Matches /t/<slug>/<id> or /t/<id> (with or without trailing path).
+    const m = forumUrl.match(/\/t\/(?:[^/]+\/)?(\d+)(?:[/?#]|$)/);
+    if (!m) return null;
+    const id = Number(m[1]);
+    return Number.isFinite(id) ? id : null;
+}
+
+function stripHtmlToText(html: string): string {
+    return html
+        .replace(/<br\s*\/?>/gi, ' ')
+        .replace(/<\/(p|div|li|h[1-6])>/gi, ' ')
+        .replace(/<[^>]+>/g, '')
+        .replace(/&nbsp;/g, ' ')
+        .replace(/&amp;/g, '&')
+        .replace(/&lt;/g, '<')
+        .replace(/&gt;/g, '>')
+        .replace(/&quot;/g, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function snippet(html: string, max: number): string {
+    const text = stripHtmlToText(html);
+    if (text.length <= max) return text;
+    return text.slice(0, max).replace(/\s+\S*$/, '') + '…';
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface DiscoursePost {
+    id: number;
+    post_number: number;
+    username: string;
+    name?: string | null;
+    created_at: string;
+    cooked: string;
+    reply_count?: number;
+    actions_summary?: { id: number; count?: number }[];
+}
+
+interface DiscourseTopicResponse {
+    id: number;
+    posts_count?: number;
+    last_posted_at?: string | null;
+    post_stream?: { posts?: DiscoursePost[] };
+}
+
+/** Discourse action id 2 = "like". */
+function likesOf(post: DiscoursePost): number {
+    const like = post.actions_summary?.find((a) => a.id === 2);
+    return like?.count ?? 0;
+}
+
+async function fetchTopicActivity(topicId: number): Promise<ForumActivity | null> {
+    const MAX_RETRIES = 2;
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            const res = await fetch(`${DISCOURSE_BASE}/t/${topicId}.json`, {
+                next: { revalidate: REVALIDATE_SECONDS },
+                signal: AbortSignal.timeout(15000),
+            });
+
+            if (res.status === 429) {
+                const waitMs = (attempt + 1) * 2000;
+                console.warn(`[discourse-models-sync] Rate limited on topic ${topicId}, waiting ${waitMs}ms (attempt ${attempt + 1})`);
+                await delay(waitMs);
+                continue;
+            }
+
+            if (!res.ok) {
+                console.error(`[discourse-models-sync] Failed to fetch topic ${topicId}: ${res.status}`);
+                return null;
+            }
+
+            const data = (await res.json()) as DiscourseTopicResponse;
+            const posts = data.post_stream?.posts ?? [];
+            if (posts.length === 0) return null;
+
+            const op = posts.find((p) => p.post_number === 1) ?? posts[0];
+            const replies = posts.filter((p) => p.post_number !== op.post_number);
+
+            // Most recent N replies from whatever Discourse returned in the
+            // default window (first ~20 posts). For low-traffic model topics
+            // this is the entire conversation.
+            const recent = [...replies]
+                .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+                .slice(0, RECENT_COMMENTS)
+                .map<ForumComment>((p) => ({
+                    postNumber: p.post_number,
+                    username: p.username,
+                    displayName: p.name ?? null,
+                    createdAt: p.created_at,
+                    likeCount: likesOf(p),
+                    snippet: snippet(p.cooked, SNIPPET_CHARS),
+                }));
+
+            const postsCount = data.posts_count ?? posts.length;
+            return {
+                topicId,
+                voteCount: likesOf(op),
+                replyCount: Math.max(0, postsCount - 1),
+                lastPostedAt: data.last_posted_at ?? null,
+                recentComments: recent,
+            };
+        } catch (err) {
+            console.error(`[discourse-models-sync] Error fetching topic ${topicId}:`, err);
+            return null;
+        }
+    }
+    return null;
+}
+
+/**
+ * Fetch activity for every unique topic ID derived from the given forum URLs.
+ * Returns a map keyed by topic ID — empty map if anything goes wrong, so
+ * the page still renders without forum data.
+ */
+export async function fetchModelForumActivity(forumUrls: string[]): Promise<ForumActivityMap> {
+    const out: ForumActivityMap = {};
+    const topicIds = Array.from(
+        new Set(
+            forumUrls
+                .map(extractTopicId)
+                .filter((id): id is number => id !== null),
+        ),
+    );
+
+    try {
+        for (let i = 0; i < topicIds.length; i += BATCH_SIZE) {
+            const batch = topicIds.slice(i, i + BATCH_SIZE);
+            const results = await Promise.allSettled(batch.map(fetchTopicActivity));
+            for (const r of results) {
+                if (r.status === 'fulfilled' && r.value) {
+                    out[r.value.topicId] = r.value;
+                }
+            }
+            if (i + BATCH_SIZE < topicIds.length) {
+                await delay(BATCH_DELAY_MS);
+            }
+        }
+    } catch (err) {
+        console.error('[discourse-models-sync] Error fetching activity:', err);
+    }
+
+    return out;
+}


### PR DESCRIPTION
Two related instrumentation/sync changes on the wiki.

## 1. Track Buy Me a Coffee modal in Google Analytics
- Adds three `gtag` events to `SessionDonateModal`:
  - `donate_modal_shown` — fires when the modal opens (after the 5-min trigger)
  - `donate_modal_clicked` — fires when the user clicks the BMC CTA (`destination` param)
  - `donate_modal_dismissed` — fires on dismiss with `method` = `backdrop` | `escape` | `no_thanks`
- Follows the same `window.gtag('event', ...)` pattern already used in `components/LanguageSwitcher.tsx`. GA4 (`G-Y7B8JQEQH9`) is loaded in `app/layout.tsx`, so no script changes were needed.

## 2. Weekly sync of forum activity onto model cards
- New `lib/discourse-models-sync.ts` extracts each model's topic ID from its `forumUrl`, calls `/t/{id}.json` on community.sunnypilot.ai (public, no auth), and returns OP like count ("votes"), reply count, last-activity timestamp, and the three most recent comments. Uses the same rate-limit retry + batched concurrency as the existing `lib/discourse-sync.ts`.
- `app/models/page.tsx` is now an async Server Component with `export const revalidate = 60 * 60 * 24 * 7` (7-day ISR), collects forum URLs from `data/models.json`, and passes the activity map down to `ModelLibrary`.
- `components/ModelLibrary.tsx` renders a new `ForumActivityPanel` on each model card: vote count, reply count, last-active relative time, and three deep-linked comment previews back to Discourse. Locale-agnostic since the lookup keys on topic ID.

## Test plan
**Donate modal events**
- [ ] Open the site, wait 5 minutes, confirm `donate_modal_shown` in GA4 DebugView
- [ ] Click "Buy me a coffee" → `donate_modal_clicked` with `destination=https://buymeacoffee.com/vinhle.co`
- [ ] Click "No thanks" → `donate_modal_dismissed` with `method=no_thanks`
- [ ] Press Escape → `method=escape`
- [ ] Click the backdrop → `method=backdrop`

**Forum sync**
- [ ] Visit `/models` on the Vercel preview; confirm the new panel renders on cards that have a `forumUrl` (30 of 98 models)
- [ ] Vote counts and recent comment authors match what appears on community.sunnypilot.ai for a known topic (e.g. WMI V12 / topic 2368)
- [ ] Comments link out correctly (open in a new tab, deep-linked to the specific post)
- [ ] Models without `forumUrl` render unchanged
- [ ] Switch locales (DE/FR/etc.) — panel still appears, because lookup is by topic ID