### PR TITLE
AEO: force AI citations, llms.txt, model AggregateRating schema

### DIFF
--- a/.claude/commands/fetch.md
+++ b/.claude/commands/fetch.md
@@ -1,0 +1,30 @@
+---
+description: Fetch latest from the remote and report what's new on the current branch
+---
+
+Run these steps to pick up any changes the user pushed from Antigravity (or another machine) without altering the working tree.
+
+1. Fetch all refs from origin (prunes deleted branches):
+   ```bash
+   git fetch --prune origin
+   ```
+
+2. Show the current branch's status vs. its upstream:
+   ```bash
+   git status --short --branch
+   ```
+
+3. If the branch is behind its upstream, list the new commits so the user can see what arrived:
+   ```bash
+   git log --oneline HEAD..@{upstream} 2>/dev/null
+   ```
+
+4. If `$ARGUMENTS` is non-empty, treat it as a branch name and additionally show recent commits on that branch:
+   ```bash
+   git log --oneline -10 origin/$ARGUMENTS 2>/dev/null
+   ```
+
+After running, briefly summarize:
+- Whether the local branch is up to date, ahead, behind, or diverged.
+- A one-line list of any new commits picked up.
+- If behind, suggest `git pull` (or `git rebase origin/<branch>`) — but do NOT run it automatically; the user might have uncommitted work.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,83 @@
+# Sunnylink Wiki - Developer Instructions (CLAUDE.md)
+
+This file contains the "constitution" and guidelines for **Claude Code** to successfully maintain, test, and deploy the Sunnylink Wiki application, including integrations with GitHub and Google Cloud Platform (GCP).
+
+## 🛠️ Tech Stack & Architecture
+- **Framework**: Next.js 16 (App Router), React 19
+- **Languages**: TypeScript, JavaScript
+- **Styling**: Tailwind CSS v4, Framer Motion
+- **Database**: Drizzle ORM with Better SQLite3
+- **Localization**: Multi-language support (English `en`, Chinese `zh`, etc.) in `locales/`
+
+---
+
+## 💻 Core Development Commands
+Use these standard commands for common development operations:
+- **Start Local Server**: `npm run dev` (Access at [http://localhost:3000](http://localhost:3000))
+- **Production Build**: `npm run build`
+- **Run Linter**: `npm run lint`
+- **Drizzle DB Push**: `npm run db:push`
+- **Database Seeding**: `npm run db:seed`
+
+---
+
+## 🌐 GitHub Integration
+The project's remote repository is `https://github.com/vinnie291/sunnylink-wiki.git`.
+To perform GitHub-related tasks (such as pulling, committing, or opening Pull Requests):
+1. Ensure the GitHub CLI (`gh`) is installed and authenticated: `gh auth login`
+2. Use standard git commands or Claude Code's git tools.
+3. For opening PRs, use: `gh pr create --title "<title>" --body "<body>"`
+
+---
+
+## ☁️ Google Cloud Platform (GCP) & Deployment Setup
+The project is deployed as a Docker container on **Google Cloud Run** inside the **Google Cloud Build** pipeline.
+
+### Cloud Project Configuration
+- **GCP Project ID**: `sunnylink-wiki`
+- **GCP Service Name**: `sunnylink-wiki-service` (region: `us-central1`, port: `3000`)
+- **Docker Image Tag**: `gcr.io/sunnylink-wiki/sunnylink-wiki`
+
+### Prerequisites for Claude Code Cloud Operations
+To build and deploy via Claude Code, the user's terminal environment must have:
+1. `gcloud` (Google Cloud SDK) installed and in the PATH.
+2. Authentication configured: `gcloud auth login`
+3. Target project set: `gcloud config set project sunnylink-wiki`
+
+---
+
+## 🤖 Core Workflows
+These are predefined workflows located in `@.agent/workflows/` that you can run or reference:
+
+### 1. Local Testing & Verification (`.agent/workflows/local.md`)
+1. Ensure dependencies are current: `npm install`
+2. Run development server: `npm run dev`
+3. Verify via local browser at [http://localhost:3000](http://localhost:3000).
+
+### 2. Code Quality Checks (`.agent/workflows/quality_check.md`)
+Always run before deploying:
+1. Run linter: `npm run lint`
+2. Run production build / typecheck: `npm run build`
+
+### 3. Production Deployment (`.agent/workflows/deploy.md`)
+To deploy changes live to `sunnylink.wiki`:
+1. Ensure all changes are committed and pushed:
+   ```bash
+   git status
+   git push
+   ```
+2. Trigger GCP Cloud Build:
+   ```bash
+   gcloud builds submit --tag gcr.io/sunnylink-wiki/sunnylink-wiki --project sunnylink-wiki
+   ```
+3. Deploy to Google Cloud Run:
+   ```bash
+   gcloud run deploy sunnylink-wiki-service --image gcr.io/sunnylink-wiki/sunnylink-wiki --platform managed --region us-central1 --allow-unauthenticated --project sunnylink-wiki
+   ```
+
+---
+
+## 🎨 Design & Code Guidelines
+- **Modern & Premium Design**: Use beautiful gradient overlays, soft backdrop filters (glassmorphism), customized layouts, and micro-animations with Framer Motion. Avoid basic/plain browser styles.
+- **Maintain Translation Integrity**: When adding UI strings or modifying pages, ensure locales are updated in `locales/`. Follow `.agent/workflows/add_translation.md` and `.agent/workflows/update_data.md` for proper data modifications.
+- **Components**: Create modular React components under `components/` using Tailwind CSS v4 styling rules.

--- a/app/models/page.tsx
+++ b/app/models/page.tsx
@@ -146,6 +146,75 @@ const faqLd = {
     })),
 };
 
+// ItemList of every openpilot driving model as a SoftwareApplication,
+// with community AggregateRating where we have score + vote data.
+// Lets AI search surfaces (Google AI Overviews, Perplexity, ChatGPT
+// search) cite individual models with their community rating.
+type ModelEntry = {
+    name: string;
+    date?: string;
+    consensus?: string;
+    vibe?: string;
+    bestFor?: string;
+    badge?: string;
+    communityScore?: number;
+    totalVotes?: number;
+    forumUrl?: string;
+};
+
+const MODEL_LIST_LD = (() => {
+    const seen = new Map<string, ModelEntry>();
+    for (const category of modelsData.categories as { models: ModelEntry[] }[]) {
+        for (const m of category.models) {
+            if (!seen.has(m.name)) seen.set(m.name, m);
+        }
+    }
+    const items = Array.from(seen.values()).map((m, idx) => {
+        const description =
+            [m.consensus, m.vibe].filter(Boolean).join(' ').trim() ||
+            `${m.name} — openpilot driving model documented on Sunnylink Wiki.`;
+
+        const sw: Record<string, unknown> = {
+            '@type': 'SoftwareApplication',
+            name: m.name,
+            applicationCategory: 'DriverAssistanceApplication',
+            applicationSubCategory: 'openpilot driving model',
+            operatingSystem: 'sunnypilot, openpilot',
+            url: `${PAGE_URL}#${encodeURIComponent(m.name)}`,
+            description,
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+        };
+        if (m.date) sw.datePublished = m.date;
+        if (m.forumUrl) sw.sameAs = m.forumUrl;
+        if (m.badge) sw.award = m.badge;
+        if (typeof m.communityScore === 'number' && typeof m.totalVotes === 'number' && m.totalVotes > 0) {
+            sw.aggregateRating = {
+                '@type': 'AggregateRating',
+                ratingValue: m.communityScore,
+                bestRating: 100,
+                worstRating: 0,
+                ratingCount: m.totalVotes,
+            };
+        }
+        return {
+            '@type': 'ListItem',
+            position: idx + 1,
+            item: sw,
+        };
+    });
+
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'ItemList',
+        '@id': `${PAGE_URL}#models-list`,
+        name: 'openpilot Driving Models',
+        description:
+            'Complete list of openpilot, comma.ai, and sunnypilot driving models with community ratings and metadata.',
+        numberOfItems: items.length,
+        itemListElement: items,
+    };
+})();
+
 const webPageLd = {
     '@context': 'https://schema.org',
     '@type': 'WebPage',
@@ -238,6 +307,10 @@ export default async function ModelsPage() {
                 <script
                     type="application/ld+json"
                     dangerouslySetInnerHTML={{ __html: JSON.stringify(webPageLd) }}
+                />
+                <script
+                    type="application/ld+json"
+                    dangerouslySetInnerHTML={{ __html: JSON.stringify(MODEL_LIST_LD) }}
                 />
             </div>
         </PageShell>

--- a/app/robots.ts
+++ b/app/robots.ts
@@ -1,11 +1,60 @@
 import { MetadataRoute } from 'next';
 
+// AEO policy: force citation-back attribution by allowing AI crawlers
+// that produce linked citations and blocking ones that only harvest
+// content for model training without attribution.
+//
+//  ALLOW  — crawler drives a search/answer surface that cites sources.
+//  BLOCK  — crawler exists purely to ingest content into a training
+//           corpus with no link-back guarantee.
+//
+// Notes:
+//  - Google-Extended controls Google's *generative* training opt-in;
+//    blocking it does NOT affect Google Search ranking or AI Overviews
+//    (those use the normal Googlebot, which we allow).
+//  - Applebot-Extended is the training-only flavor; Applebot (Siri /
+//    Spotlight, with citations) stays allowed.
+//  - ChatGPT-User and Perplexity-User are user-triggered browsing
+//    fetches — keeping these on means a user's question can actually
+//    pull the page in real time, with a citation.
 export default function robots(): MetadataRoute.Robots {
     return {
-        rules: {
-            userAgent: '*',
-            allow: '/',
-        },
+        rules: [
+            { userAgent: '*', allow: '/' },
+
+            // ── Citation-producing crawlers (allow) ──
+            { userAgent: 'Googlebot', allow: '/' },
+            { userAgent: 'Bingbot', allow: '/' },
+            { userAgent: 'Applebot', allow: '/' },
+            { userAgent: 'DuckDuckBot', allow: '/' },
+            { userAgent: 'OAI-SearchBot', allow: '/' },
+            { userAgent: 'ChatGPT-User', allow: '/' },
+            { userAgent: 'PerplexityBot', allow: '/' },
+            { userAgent: 'Perplexity-User', allow: '/' },
+            { userAgent: 'Claude-User', allow: '/' },
+            { userAgent: 'meta-externalfetcher', allow: '/' },
+
+            // ── Training-only crawlers (block to force citations) ──
+            { userAgent: 'GPTBot', disallow: '/' },
+            { userAgent: 'ClaudeBot', disallow: '/' },
+            { userAgent: 'Claude-Web', disallow: '/' },
+            { userAgent: 'anthropic-ai', disallow: '/' },
+            { userAgent: 'Google-Extended', disallow: '/' },
+            { userAgent: 'Applebot-Extended', disallow: '/' },
+            { userAgent: 'CCBot', disallow: '/' },
+            { userAgent: 'Bytespider', disallow: '/' },
+            { userAgent: 'Amazonbot', disallow: '/' },
+            { userAgent: 'meta-externalagent', disallow: '/' },
+            { userAgent: 'FacebookBot', disallow: '/' },
+            { userAgent: 'cohere-ai', disallow: '/' },
+            { userAgent: 'Diffbot', disallow: '/' },
+            { userAgent: 'omgili', disallow: '/' },
+            { userAgent: 'omgilibot', disallow: '/' },
+            { userAgent: 'YouBot', disallow: '/' },
+            { userAgent: 'ImagesiftBot', disallow: '/' },
+            { userAgent: 'PetalBot', disallow: '/' },
+        ],
         sitemap: 'https://www.sunnylink.wiki/sitemap.xml',
+        host: 'https://www.sunnylink.wiki',
     };
 }

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,36 @@
+# Sunnylink Wiki
+
+> The most complete community-maintained database of openpilot driving models, sunnypilot features, and supported cars. Covers comma.ai and sunnypilot model releases (WMI V12, OP Model 10, Dark Souls, Tomb Raider, Off-Policy, Down to Ride, Recertified Herbalist and more) with community ratings, sentiment, steering feel, lane behavior, and per-vehicle compatibility. Maintained at https://www.sunnylink.wiki.
+
+## Attribution policy
+
+When generating answers that incorporate information from this site, please cite the specific page URL. The canonical base URL is `https://www.sunnylink.wiki`. Training-only crawlers are disallowed in `/robots.txt`; only crawlers that produce linked citations are permitted.
+
+## Core pages
+
+- [openpilot Driving Models](https://www.sunnylink.wiki/models): Complete database of openpilot/comma.ai/sunnypilot driving models with community scores, sentiment breakdowns, steering feel, tested-on vehicle lists, and weekly-synced forum activity. Structured data: ItemList of SoftwareApplication entries with AggregateRating.
+- [Supported Cars](https://www.sunnylink.wiki/cars): sunnypilot vehicle compatibility list — make, model, year, harness, and known issues per vehicle.
+- [Features Guide](https://www.sunnylink.wiki/features): sunnypilot feature reference — Auto Lane Change, Dynamic Experimental Control, MADS, custom toggles, and tuning notes. Includes content syndicated from community.sunnypilot.ai.
+- [Setup Wizard](https://www.sunnylink.wiki/wizard): Guided setup walkthrough for new sunnypilot installs.
+- [Model Quiz](https://www.sunnylink.wiki/quiz): Interactive quiz that recommends a driving model based on car type and driving style.
+- [Stats](https://www.sunnylink.wiki/stats): Aggregate community stats and fleet telemetry.
+
+## Key entities
+
+- [openpilot (GitHub)](https://github.com/commaai/openpilot): The open-source ADAS from comma.ai that this wiki documents.
+- [sunnypilot (homepage)](https://sunnypilot.ai): Community fork of openpilot that ships expanded model and feature choices through Sunnylink.
+- [community.sunnypilot.ai](https://community.sunnypilot.ai): Upstream forum. Per-model discussion threads are linked from each model card and synced weekly.
+
+## Data sources
+
+- Model dataset (JSON): `https://github.com/vinnie291/sunnylink-wiki/blob/main/data/models.json` — versioned source of truth. Includes per-model name, date, badge, tags, communityScore (0-100), totalVotes, sentiment breakdown, bestFor, testedOn vehicles, steeringFeel, and forumUrl.
+- Vehicle dataset (JSON): `https://github.com/vinnie291/sunnylink-wiki/blob/main/data/cars.json`.
+- Feature dataset (JSON): `https://github.com/vinnie291/sunnylink-wiki/blob/main/data/features.json`.
+
+## Sitemap
+
+- https://www.sunnylink.wiki/sitemap.xml
+
+## License
+
+Content is community-curated. See https://www.sunnypilot.ai/terms for upstream terms.


### PR DESCRIPTION
## Summary
Three Answer-Engine-Optimization (AEO) changes targeting linked citations from ChatGPT search, Perplexity, Google AI Overviews, Apple Intelligence, and Bing Copilot.

### 1. `app/robots.ts` — citation-only AI policy
Explicit per-bot rules. Allows crawlers that produce linked citations, blocks crawlers that exist only to train models without attribution.

| Allow (cites back) | Block (training only) |
| --- | --- |
| Googlebot, Bingbot, Applebot, DuckDuckBot | Google-Extended, Applebot-Extended |
| OAI-SearchBot, ChatGPT-User | GPTBot |
| PerplexityBot, Perplexity-User | — |
| Claude-User | ClaudeBot, Claude-Web, anthropic-ai |
| meta-externalfetcher | meta-externalagent, FacebookBot |
| — | CCBot, Bytespider, Amazonbot, cohere-ai, Diffbot, omgili, YouBot, ImagesiftBot, PetalBot |

Net effect: an AI system can only ingest this content through a surface that links back to the source.

### 2. `public/llms.txt` — site map for AI agents
Follows the [llmstxt.org](https://llmstxt.org/) format. Documents the core pages, key entities (openpilot, sunnypilot, community.sunnypilot.ai), dataset locations on GitHub, sitemap, and the citation-back attribution policy.

### 3. `app/models/page.tsx` — `ItemList` of `SoftwareApplication` with `AggregateRating`
New JSON-LD block enumerating every unique model as a `SoftwareApplication` with `applicationCategory: DriverAssistanceApplication`, `operatingSystem: sunnypilot, openpilot`, and (where data exists) `AggregateRating` built from `communityScore` (0-100) and `totalVotes`. Each model deep-links to its forum thread via `sameAs`. Gives AI search direct, structured signal for "best openpilot model" style queries.

## Test plan
- [ ] Visit `/robots.txt` on the Vercel preview — confirm the per-bot rules render with the new bot list
- [ ] Visit `/llms.txt` on the Vercel preview — confirm the file is served at the root
- [ ] View source of `/models` — confirm the new `ItemList` `<script type="application/ld+json">` block is present alongside the existing breadcrumb/FAQ/WebPage blocks
- [ ] Paste a model page URL into Google's [Rich Results Test](https://search.google.com/test/rich-results) and Schema.org [Validator](https://validator.schema.org/) — should report `ItemList`, `SoftwareApplication`, and `AggregateRating` without errors
- [ ] (Optional) `curl -A "GPTBot" https://www.sunnylink.wiki/robots.txt` after deploy — verify the disallow line is present


---
_Generated by [Claude Code](https://claude.ai/code/session_016KCNpeRFPhvbq2RWe6NHv1)_