### PR TITLE
Drive simulator: real red-light hold + minimal top-left HUD

### DIFF
--- a/components/DriveSimulation.tsx
+++ b/components/DriveSimulation.tsx
@@ -434,6 +434,10 @@ export default function DriveSimulation({ profile, seedKey, disableRainbow, hide
     const speedRef = useRef(speed);
     const unitRef = useRef(unit);
     const scenarioRef = useRef<Scenario>(SCENARIOS[profile.scenarioKey]);
+    // Current traffic-light colour, written by the physics loop and read by
+    // drawFrame so the rendered light matches the car's stop/hold behaviour
+    // (the two run as separate passes and must not disagree).
+    const lightStateRef = useRef<'red' | 'yellow' | 'green'>('red');
     useEffect(() => { profileRef.current = profile; }, [profile]);
     useEffect(() => { speedRef.current = speed; }, [speed]);
     useEffect(() => { unitRef.current = unit; }, [unit]);
@@ -719,21 +723,15 @@ export default function DriveSimulation({ profile, seedKey, disableRainbow, hide
                                 const by = poleTopY - boxH / 2;
                                 svg += `<rect x="${bx.toFixed(2)}" y="${by.toFixed(2)}" width="${boxW.toFixed(2)}" height="${boxH.toFixed(2)}" rx="${(1.5 * scale).toFixed(2)}" fill="#1e293b" stroke="#475569" stroke-width="${(0.6 * scale).toFixed(2)}" />`;
                                 
-                                let lightState: 'red' | 'yellow' | 'green' = 'red';
-                                if (profile.afraidOfGreen) {
-                                    lightState = 'green';
-                                } else if (profile.creepMode !== 'none') {
-                                    lightState = 'red';
-                                } else {
-                                    if (stopDistance < 18) {
-                                        lightState = 'green';
-                                    } else if (stopDistance < 24) {
-                                        lightState = 'yellow';
-                                    } else {
-                                        lightState = 'red';
-                                    }
-                                }
-                                
+                                // Mirror the physics loop's current light colour
+                                // (set in tick) so the rendered signal agrees with
+                                // the car's stop/hold behaviour. In the static
+                                // (reduced-motion) redraw the loop isn't running, so
+                                // this reads its last/default value — a red light,
+                                // which is fine to show at rest.
+                                const lightState: 'red' | 'yellow' | 'green' =
+                                    profile.afraidOfGreen ? 'green' : lightStateRef.current;
+
                                 const r = 2.0 * scale;
                                 const cyRed = poleTopY - 4.5 * scale;
                                 const cyYellow = poleTopY;
@@ -827,81 +825,18 @@ export default function DriveSimulation({ profile, seedKey, disableRainbow, hide
                 
                 const intersectionId = Math.floor(currentIntersectionZ / intersectionInterval);
                 const isStopSign = profile.stopSignStops ? true : (profile.afraidOfGreen || profile.creepMode !== 'none' ? false : (intersectionId % 2 === 0));
-                
+
+                // Minimum time the car holds at a stopped red light before the
+                // signal cycles to green — long enough to read as a real light
+                // rather than a momentary tap-stop.
+                const RED_LIGHT_HOLD_S = 3.5;
+
                 let lightState: 'red' | 'yellow' | 'green' = 'red';
+
                 if (profile.afraidOfGreen) {
+                    // Light is green but the model hesitates to proceed through it.
                     lightState = 'green';
-                } else if (profile.creepMode !== 'none') {
-                    lightState = 'red';
-                } else {
-                    if (stopDistance < 18) {
-                        lightState = 'green';
-                    } else if (stopDistance < 24) {
-                        lightState = 'yellow';
-                    } else {
-                        lightState = 'red';
-                    }
-                }
-                
-                if (isStopSign || lightState === 'red') {
-                    if (dToStop > 0) {
-                        let decel = 1.0;
-                        if (profile.lateBraking) {
-                            decel = Math.min(1.0, Math.pow(dToStop / 18, 2));
-                        } else if (profile.pathSmoothness < 0.4) {
-                            decel = Math.min(1.0, dToStop / 40);
-                        } else {
-                            decel = Math.min(1.0, dToStop / 30);
-                        }
-                        targetSpeedMph = Math.min(targetSpeedMph, speedMph * decel);
-                        stopTime = 0;
-                        
-                        if (isStopSign) {
-                            currentStatus = "🛑 APPROACHING STOP SIGN";
-                            statusColor = "#f87171"; // red-400
-                        } else {
-                            currentStatus = "🔴 APPROACHING RED LIGHT";
-                            statusColor = "#f87171"; // red-400
-                        }
-                    } else {
-                        stopTime += dt;
-                        if (profile.creepMode === 'creep') {
-                            targetSpeedMph = 2.5;
-                            currentStatus = "🐌 CREEPING AT RED";
-                            statusColor = "#fbbf24"; // amber-400
-                        } else if (profile.creepMode === 'fails_stop') {
-                            if (stopTime > 1.0) {
-                                targetSpeedMph = 4.0;
-                                currentStatus = "🚨 FAILING TO STAY STOPPED";
-                                statusColor = "#ef4444"; // red-500
-                            } else {
-                                targetSpeedMph = 0.0;
-                                currentStatus = "🛑 STOPPED AT RED LIGHT";
-                                statusColor = "#ef4444"; // red-500
-                            }
-                        } else if (isStopSign) {
-                            if (stopTime > 1.8) {
-                                targetSpeedMph = speedMph;
-                                currentStatus = "🟢 RECOVERING SPEED";
-                                statusColor = "#34d399"; // emerald-400
-                            } else {
-                                targetSpeedMph = 0.0;
-                                currentStatus = "🛑 STOPPED AT STOP SIGN";
-                                statusColor = "#ef4444"; // red-500
-                            }
-                        } else {
-                            if (stopTime > 2.0) {
-                                targetSpeedMph = speedMph;
-                                currentStatus = "🟢 RECOVERING SPEED";
-                                statusColor = "#34d399"; // emerald-400
-                            } else {
-                                targetSpeedMph = 0.0;
-                                currentStatus = "🛑 STOPPED AT RED LIGHT";
-                                statusColor = "#ef4444"; // red-500
-                            }
-                        }
-                    }
-                } else if (lightState === 'green' && profile.afraidOfGreen) {
+                    stopTime = 0;
                     if (dToStop > 0 && dToStop < 22) {
                         targetSpeedMph = Math.min(targetSpeedMph, 11.0);
                         currentStatus = "⚠️ HESITATING AT GREEN";
@@ -909,7 +844,77 @@ export default function DriveSimulation({ profile, seedKey, disableRainbow, hide
                     } else {
                         targetSpeedMph = speedMph;
                     }
+                } else if (dToStop > 0) {
+                    // Approaching the line — decelerate. Red lights stay red on
+                    // approach (a real light you stop at doesn't pre-empt green).
+                    let decel = 1.0;
+                    if (profile.lateBraking) {
+                        decel = Math.min(1.0, Math.pow(dToStop / 18, 2));
+                    } else if (profile.pathSmoothness < 0.4) {
+                        decel = Math.min(1.0, dToStop / 40);
+                    } else {
+                        decel = Math.min(1.0, dToStop / 30);
+                    }
+                    targetSpeedMph = Math.min(targetSpeedMph, speedMph * decel);
+                    stopTime = 0;
+                    lightState = 'red';
+
+                    if (isStopSign) {
+                        currentStatus = "🛑 APPROACHING STOP SIGN";
+                    } else {
+                        currentStatus = "🔴 APPROACHING RED LIGHT";
+                    }
+                    statusColor = "#f87171"; // red-400
+                } else {
+                    // Stopped at the line.
+                    stopTime += dt;
+                    if (profile.creepMode === 'creep') {
+                        lightState = 'red';
+                        targetSpeedMph = 2.5;
+                        currentStatus = "🐌 CREEPING AT RED";
+                        statusColor = "#fbbf24"; // amber-400
+                    } else if (profile.creepMode === 'fails_stop') {
+                        lightState = 'red';
+                        if (stopTime > 1.0) {
+                            targetSpeedMph = 4.0;
+                            currentStatus = "🚨 FAILING TO STAY STOPPED";
+                            statusColor = "#ef4444"; // red-500
+                        } else {
+                            targetSpeedMph = 0.0;
+                            currentStatus = "🛑 STOPPED AT RED LIGHT";
+                            statusColor = "#ef4444"; // red-500
+                        }
+                    } else if (isStopSign) {
+                        // Stop signs are a brief full stop, then proceed.
+                        lightState = 'red';
+                        if (stopTime > 1.8) {
+                            targetSpeedMph = speedMph;
+                            currentStatus = "🟢 RECOVERING SPEED";
+                            statusColor = "#34d399"; // emerald-400
+                        } else {
+                            targetSpeedMph = 0.0;
+                            currentStatus = "🛑 STOPPED AT STOP SIGN";
+                            statusColor = "#ef4444"; // red-500
+                        }
+                    } else {
+                        // Red light: hold for the full signal duration, then the
+                        // light turns green and the car proceeds.
+                        if (stopTime > RED_LIGHT_HOLD_S) {
+                            lightState = 'green';
+                            targetSpeedMph = speedMph;
+                            currentStatus = "🟢 GREEN — PROCEEDING";
+                            statusColor = "#34d399"; // emerald-400
+                        } else {
+                            lightState = 'red';
+                            targetSpeedMph = 0.0;
+                            currentStatus = "🛑 STOPPED AT RED LIGHT";
+                            statusColor = "#ef4444"; // red-500
+                        }
+                    }
                 }
+
+                // Publish for drawFrame so the rendered light matches the physics.
+                lightStateRef.current = lightState;
             }
 
             // Implement speed fluctuations in yoyoMode trailing a lead car

--- a/components/DriveSimulation.tsx
+++ b/components/DriveSimulation.tsx
@@ -1059,8 +1059,7 @@ export default function DriveSimulation({ profile, seedKey, disableRainbow, hide
             if (statusTextRef.current) {
                 statusTextRef.current.textContent = currentStatus;
                 statusTextRef.current.style.color = statusColor;
-                statusTextRef.current.style.borderColor = statusColor + "40"; // 25% opacity border matching the color
-                
+
                 // Add pulsing animation for warnings and critical snaps
                 if (currentStatus.startsWith("🚨") || currentStatus.startsWith("🔴") || currentStatus.startsWith("🛑")) {
                     statusTextRef.current.style.animation = "pulse 1.2s cubic-bezier(0.4, 0, 0.6, 1) infinite";
@@ -1221,28 +1220,25 @@ export default function DriveSimulation({ profile, seedKey, disableRainbow, hide
                 </g>
             </svg>
 
-            {/* personality label (top-left) — shrunk and capped so it never
-                crowds the speed indicator at any simulator size. */}
-            <div
-                className="absolute left-[4%] top-[8%] select-none pointer-events-none max-w-[28%] truncate"
-                style={{ color: profile.pathColor }}
-            >
-                <span className="text-[clamp(8px,1.7cqw,12px)] font-bold tracking-[0.18em] uppercase opacity-90 whitespace-nowrap">
+            {/* Route info (top-left): a thin, subtle personality label with the
+                live drive status stacked beneath it. Both stay minimal so they
+                never crowd the speed indicator at any simulator size. */}
+            <div className="absolute left-[4%] top-[8%] select-none pointer-events-none max-w-[55%] flex flex-col gap-0.5">
+                <span
+                    className="text-[clamp(7px,1.4cqw,10px)] font-medium tracking-[0.2em] uppercase opacity-55 whitespace-nowrap truncate [text-shadow:0_1px_2px_rgba(0,0,0,0.6)]"
+                    style={{ color: profile.pathColor }}
+                >
                     {profile.label}
                 </span>
-            </div>
-
-            {/* Dynamic Telemetry Status (top-right) */}
-            {!hideStatus && (
-                <div className="absolute right-[4%] top-[8%] select-none pointer-events-none max-w-[50%] truncate text-right">
+                {!hideStatus && (
                     <span
                         ref={statusTextRef}
-                        className="text-[clamp(8px,1.7cqw,12px)] font-bold tracking-[0.12em] uppercase px-2.5 py-1 rounded bg-slate-900/80 border border-white/10 text-emerald-400 shadow-md backdrop-blur-sm transition-all duration-300"
+                        className="text-[clamp(7px,1.5cqw,11px)] font-semibold tracking-[0.1em] uppercase text-emerald-400 truncate transition-colors duration-300 [text-shadow:0_1px_3px_rgba(0,0,0,0.85)]"
                     >
                         SYSTEM ACTIVE
                     </span>
-                </div>
-            )}
+                )}
+            </div>
 
 {/* subtle vignette at top to fade the scene */}
             <div className="pointer-events-none absolute inset-x-0 top-0 h-1/3 bg-gradient-to-b from-black/45 to-transparent" />


### PR DESCRIPTION
## Summary
Two changes to the drive model visualizer (`components/DriveSimulation.tsx`).

### 1. Red lights actually stop and hold ~3.5s
The traffic-light state was distance-based and flipped to green *before* the car reached the line, so regular models rolled through and the "stopped at red light" hold was never reached. Reworked the city intersection logic so a red light stays red on approach, brings the car to a full stop at the line, holds for `RED_LIGHT_HOLD_S` (3.5s), then cycles to green and proceeds — reading like a real signal.

Physics and the SVG render previously computed light colour independently; they now share a `lightStateRef` so the drawn signal always matches the car's behaviour. Stop signs (1.8s) and creep / fails-to-stay-stopped modes are unchanged.

### 2. Minimal top-left HUD
Thinned the personality/route label (lighter weight, lower opacity, subtle text-shadow) and moved the live drive status out of the chunky top-right pill into the top-left, stacked beneath the label. Dropped the status pill's background, border, shadow and blur for a subtle, minimal HUD. Status still recolors and pulses for alerts (e.g. "STOPPED AT RED LIGHT"); the now-unused `borderColor` JS write was removed.

## Test plan
- [ ] Open a model card / fullscreen visualizer with a city scenario; confirm the car comes to a full stop at a red light and holds ~3.5s before the light turns green and it proceeds
- [ ] Confirm the traffic-light graphic shows red during the stop/hold and green only when the car moves off (no green-while-stopped desync)
- [ ] Confirm stop signs still do their brief ~1.8s stop, and creep / fails-to-stay-stopped models behave as before
- [ ] Confirm the route label + status text now sit minimally in the top-left, top-right is clear, and the status still recolors/pulses on alerts
- [ ] `npm run lint && npm run build` locally (ESLint can't run in the web sandbox)

---
_Generated by [Claude Code](https://claude.ai/code/session_016KCNpeRFPhvbq2RWe6NHv1)_